### PR TITLE
bindCOLS error workaround in runMultiUMAP function

### DIFF
--- a/R/runMultiUMAP.R
+++ b/R/runMultiUMAP.R
@@ -88,11 +88,18 @@ setGeneric("calculateMultiUMAP", function(x, ...) standardGeneric("calculateMult
 #' @rdname runMultiUMAP
 #' @importFrom utils head
 #' @importFrom uwot umap
+#' @importFrom DelayedArray DelayedArray
 setMethod("calculateMultiUMAP", "ANY", function(x, ..., metric="euclidean") {
     if (length(x)==0) {
         stop("'x' must contain one or more matrices")
     }
     mult.metrics <- .compute_multi_modal_metrics(x, metric=metric)
+
+    # Work around Bioconductor/DelayedArray#100 for the time being.
+    if (any(vapply(x, is, class="DelayedArray", TRUE))) {
+        x <- lapply(x, DelayedArray)
+    }
+
     combined <- as.matrix(do.call(cbind, x))
     umap(combined, metric=mult.metrics, ...)
 })

--- a/tests/testthat/test-multi-umap.R
+++ b/tests/testthat/test-multi-umap.R
@@ -28,3 +28,23 @@ test_that("multi-modal UMAP works as expected", {
     output2 <- runMultiUMAP(sce, assays=1, dimreds=1, altexps=1, altexp.assay=1, n_components=10)
     expect_identical(output, reducedDim(output2, "MultiUMAP"))
 })
+
+test_that("multi-modal UMAP works with mixed DelayedArrays and matrices", {
+    set.seed(9999)
+    output1 <- calculateMultiUMAP(things)
+
+    set.seed(9999)
+    output2 <- calculateMultiUMAP(lapply(things, DelayedArray::DelayedArray))
+    expect_identical(output1, output2)
+
+    # Same result for SCEs.
+    sce <- SingleCellExperiment(list(X=DelayedArray::DelayedArray(t(stuff))),
+                                reducedDims=list(Y=stuff[,1:5]), altExps=list(Z=SummarizedExperiment(t(stuff[,1:20]))))
+
+    set.seed(9999)
+    output3 <- calculateMultiUMAP(things, n_components=10)
+
+    set.seed(9999)
+    output4 <- runMultiUMAP(sce, assays=1, dimreds=1, altexps=1, altexp.assay=1, n_components=10)
+    expect_identical(output3, reducedDim(output4, "MultiUMAP"))
+})


### PR DESCRIPTION
This PR provide a workaround for `runMultiUMAP()` that encountered the same issue with DelayedArray format that was previously reported in #5 for `rescaleByNeighbors()` and was fixed in 6d61b526172271f4bc6cca573863247e0fbff903.

Error message when the `SingleCellExperiment` object has assays stored as DelayedMatrix objects:
```
Error in (function (classes, fdef, mtable)  : 
  unable to find an inherited method for function ‘bindCOLS’ for signature ‘"DelayedMatrix"’
```